### PR TITLE
Support full topics

### DIFF
--- a/lib/weddell/client.ex
+++ b/lib/weddell/client.ex
@@ -91,6 +91,10 @@ defmodule Weddell.Client do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
+  def start_without_name do
+    GenServer.start(__MODULE__, :ok)
+  end
+
   def start_link_without_name do
     GenServer.start_link(__MODULE__, :ok)
   end

--- a/lib/weddell/client/publisher.ex
+++ b/lib/weddell/client/publisher.ex
@@ -86,8 +86,12 @@ defmodule Weddell.Client.Publisher do
         _message ->
           PubsubMessage.new()
       end)
-    request = PublishRequest.new(topic: Util.full_topic(client.project, topic),
-                                 messages: messages)
+
+      full_topic = case topic do
+        "projects/" <> _ -> topic
+        partial_topic -> Util.full_topic(client.project, partial_topic)
+      end
+    request = PublishRequest.new(topic: full_topic, messages: messages)
     client.channel
     |> stub_module().publish(request, Client.request_opts())
     |> case do


### PR DESCRIPTION
Allow full topics to be passed in, starting with `"projects/"` , to bypass project from config.